### PR TITLE
Fix input parsing & allocations

### DIFF
--- a/rind.c
+++ b/rind.c
@@ -11,8 +11,9 @@ rind_t *rind_create(const char *name, int age, int milkperday) {
      || age<0||age>30
      || milkperday<15||milkperday>40)
         return NULL;
-    rind_t *r = calloc(1, sizeof *r);
+    rind_t *r = malloc(sizeof *r);
     if (!r) return NULL;
+    memset(r, 0, sizeof *r);
     strncpy(r->name, name, RIND_NAME_LEN);
     r->name[RIND_NAME_LEN] = '\0';
     r->age        = age;


### PR DESCRIPTION
## Summary
- avoid using unsupported strtol/strcspn
- handle interactive input with scanf
- use malloc/memset instead of calloc for rinder

## Testing
- `gcc -std=c11 -Wall -Wextra -pedantic main.c ll.c rind.c app.c -o app -lm`

------
https://chatgpt.com/codex/tasks/task_e_6856f4eb40b48333836f4ba042f87dc5